### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,227 @@
+# AGENTS.md
+
+## Repository Overview
+
+`hsm-ref-impl` holds MOSIP's reference implementations of the
+`io.mosip.kernel.core.keymanager.spi.KeyStore` interface for three real,
+commercial Hardware Security Modules (HSMs):
+
+- **AWS CloudHSM** (`hsm-keystore-impl/aws-cloudhsm-impl`)
+- **nCipher / Thales nShield HSM** (`hsm-keystore-impl/ncipher-hsm-impl`)
+- **SafeNet Luna HSM** (`hsm-keystore-impl/safenet-luna-impl`)
+
+These are not a software simulator. Each module is a thin JCE (Java
+Cryptography Extension) provider wrapper around a real vendor SDK, used by
+MOSIP's `kernel-keymanager-service` to generate, store, and use signing/
+encryption keys that live inside a physical or cloud HSM. There is no
+SoftHSM, PKCS#11 simulator, or dev-mode key store in this repository — every
+module here talks to actual HSM hardware or a cloud HSM service and expects
+that hardware/service to be reachable and provisioned.
+
+Each module is an independent, standalone Maven project (there is no
+aggregator/parent `pom.xml` at the repository root). They are built and
+deployed one at a time, matching whichever HSM vendor a given MOSIP
+deployment uses.
+
+## Technology Stack
+
+- **Language**: Java, compiled for Java 21 (`maven.compiler.source` /
+  `maven.compiler.target` = `21` in each module's `pom.xml`).
+- **Build tool**: Apache Maven.
+- **Shared MOSIP dependency**: `io.mosip.kernel:kernel-keymanager-service`
+  (version `1.2.1-SNAPSHOT`, classifier `lib`) in all three modules, plus
+  `io.mosip.kernel:kernel-core` in the nCipher and SafeNet Luna modules.
+  These are MOSIP kernel artifacts, not vendor artifacts.
+- **Vendor SDK dependencies** (one per module, proprietary — see
+  Configuration section below):
+  - `com.amazonaws.cloudhsm:cloudhsm-jce:5.14.0` (AWS CloudHSM JCE provider)
+  - `com.ncipher.km:nfkm:1.0.0` (nCipher/Thales `nfkm` Java library)
+  - `com.safenetinc:luna:1.10.0` (SafeNet Luna JCE provider)
+- **License**: Mozilla Public License 2.0 (`LICENSE`).
+
+## Build & Test Commands
+
+There are no automated tests in this repository (no `src/test` directories
+in any module) and no CI workflows (no `.github/workflows` directory).
+Building means compiling and packaging one module at a time from inside
+that module's directory, because there is no root `pom.xml`:
+
+```shell
+cd hsm-keystore-impl/aws-cloudhsm-impl
+mvn clean install
+```
+
+```shell
+cd hsm-keystore-impl/ncipher-hsm-impl
+mvn clean install
+```
+
+```shell
+cd hsm-keystore-impl/safenet-luna-impl
+mvn clean install
+```
+
+Each `mvn clean install` will fail unless the vendor SDK dependency for that
+module (see Configuration) and the `io.mosip.kernel` snapshot artifacts are
+already available in your local Maven repository or a reachable Maven
+repository/mirror — none of these are on Maven Central.
+
+## Configuration
+
+- **Vendor SDKs are not bundled and are not on public Maven Central.**
+  Before building a module you must obtain the matching vendor SDK from the
+  HSM vendor (AWS CloudHSM client SDK, nCipher/Thales Security World client
+  software, or SafeNet Luna client software) and install the corresponding
+  JAR into your local Maven repository, for example:
+
+  ```shell
+  mvn install:install-file -Dfile=cloudhsm-jce-5.14.0.jar -DgroupId=com.amazonaws.cloudhsm -DartifactId=cloudhsm-jce -Dversion=5.14.0 -Dpackaging=jar
+  ```
+
+  Substitute the group ID, artifact ID, version, and JAR path shown in the
+  target module's `pom.xml` for the other two vendors.
+
+- **Runtime credentials/parameters are passed in code, not in a config
+  file checked into this repo.** Each implementation class is constructed
+  with a `Map<String, String> params` (see the constructors in
+  `AWSCloudHSMKeyStoreImpl.java`, `NCipherHSMKeyStoreImpl.java`, and
+  `SafenetLunaKeyStoreImpl.java`). The caller (MOSIP's keymanager service)
+  supplies these keys at runtime — this repo has no properties/YAML file
+  defining them:
+  - AWS CloudHSM: `keyStoreType`, `keyStoreFile`, `localKeyStorePwd`,
+    `cuUserName`, `cuPassword`, plus the shared `KeymanagerConstant` keys
+    for symmetric/asymmetric key algorithm, key size, and certificate sign
+    algorithm.
+  - nCipher: `keyStoreType`, `keyStoreFile`, `cardProtection`, plus the
+    same shared `KeymanagerConstant` keys.
+  - SafeNet Luna: `keyStoreType`, `slotNo`, `partitionPwd`, plus the same
+    shared `KeymanagerConstant` keys.
+- **Never hard-code or commit real HSM credentials** (crypto user
+  password, card protection password, partition password) anywhere in this
+  repository. The source intentionally marks the places passwords are used
+  with `@SuppressWarnings("findsecbugs:HARD_CODE_PASSWORD")` because the
+  password strings are passed in from external configuration at
+  construction time, not hard-coded — keep it that way in any change.
+
+## Project Structure Notes
+
+```text
+hsm-ref-impl/
+  LICENSE
+  README.md
+  hsm-keystore-impl/
+    aws-cloudhsm-impl/
+      pom.xml
+      src/main/java/io/mosip/keymanager/hsm/impl/
+        AWSCloudHSMKeyStoreImpl.java
+        ApplicationCallBackHandler.java
+    ncipher-hsm-impl/
+      pom.xml
+      src/main/java/io/mosip/keymanager/hsm/impl/
+        NCipherHSMKeyStoreImpl.java
+    safenet-luna-impl/
+      pom.xml
+      src/main/java/io/mosip/keymanager/hsm/impl/
+        SafenetLunaKeyStoreImpl.java
+```
+
+- All three modules use the same Java package name
+  (`io.mosip.keymanager.hsm.impl`) but live in separate Maven modules —
+  only one implementation is ever on the classpath of a given deployment.
+- Each implementation class implements the same MOSIP kernel interface
+  (`io.mosip.kernel.core.keymanager.spi.KeyStore`) with the same method set
+  (`getAllAlias`, `getKey`, `getAsymmetricKey`, `getPrivateKey`,
+  `getPublicKey`, `getCertificate`, `getSymmetricKey`, `deleteKey`,
+  `generateAndStoreAsymmetricKey`, `generateAndStoreSymmetricKey`,
+  `storeCertificate`, `getKeystoreProviderName`), so behavior should stay
+  consistent across modules unless a vendor's SDK genuinely requires
+  otherwise.
+- The AWS CloudHSM module is the only one with an optional in-memory key
+  reference cache (`enableKeyReferenceCache`, controlled by the
+  `KeymanagerConstant.FLAG_KEY_REF_CACHE` param) — the other two modules do
+  not cache key entries.
+- This is a small, flat repository. A single root `AGENTS.md` is
+  sufficient; no per-module `AGENTS.md` files were added because the three
+  modules share one build tool, one Java target, and one interface
+  contract, and differ only in which vendor JAR and credential fields they
+  use (documented above).
+
+## Development Workflow
+
+1. Fork the repository and clone your fork.
+2. Branch from `develop` (the repository's actual integration branch —
+   `git ls-remote` shows both `develop` and `develop-java21`; `develop` is
+   the current MOSIP target branch for new work unless a maintainer tells
+   you otherwise).
+3. Make changes inside the relevant module directory only
+   (`hsm-keystore-impl/<vendor>-impl/`).
+4. Build that module with Maven as shown above and fix any compile errors.
+   Because there are no unit tests, manual/integration verification against
+   real (or vendor-provided test) HSM hardware is the only way to confirm
+   runtime behavior — do not assume a clean `mvn compile` means the HSM
+   integration works.
+5. Keep the three implementations' method behavior consistent with each
+   other and with the shared `io.mosip.kernel.core.keymanager.spi.KeyStore`
+   contract unless a vendor SDK genuinely forces a difference; note any such
+   difference in the code and in your PR description.
+
+## Pull Request Guidelines
+
+- Target the `develop` branch.
+- Keep changes scoped to one module per PR where practical, since each
+  module is built and released independently.
+- Do not add real HSM hostnames, crypto user names, passwords, PINs, or
+  partition/slot identifiers to source, `pom.xml`, or commit history.
+- Reference the tracking issue/ticket in the PR description.
+- Since there is no CI in this repository, describe in the PR how you
+  validated the change (module built successfully, and if possible, tested
+  against real or vendor test HSM hardware).
+
+## Repository-Specific Considerations
+
+- **These are real HSM integrations, not a dev simulator.** Do not treat
+  this repo like a local-only test double — every module here is meant to
+  be built and deployed against genuine HSM hardware/service (AWS CloudHSM,
+  nCipher nShield, or SafeNet Luna). Never point these implementations at
+  production HSM partitions/slots from a development or test context.
+- **Vendor SDKs are proprietary and not redistributable from this repo.**
+  Expect `mvn install` to fail on a clean machine until the matching vendor
+  JAR is installed locally (see Configuration).
+- **Passwords/PINs flow through the `params` map at construction time**,
+  sourced from MOSIP's keymanager configuration outside this repo — never
+  add a default, fallback, or example password inside any of the three
+  `*KeyStoreImpl.java` files.
+- **No aggregator `pom.xml`, no tests, no CI**: verify any build/test claim
+  yourself by running the module-level `mvn` commands above; do not assume
+  a repository-level build exists.
+
+## Agent rules
+
+### Do
+
+1. Verify any new build, test, or config claim against the actual
+   `pom.xml` and `.java` files in the relevant module before writing it
+   down.
+2. Work inside a single module directory (`hsm-keystore-impl/<vendor>-impl`)
+   per change, and build that module with Maven to confirm it compiles.
+3. Keep the three vendor implementations' public method behavior aligned
+   with the shared `io.mosip.kernel.core.keymanager.spi.KeyStore` interface
+   contract.
+4. Treat passwords, PINs, slot numbers, and partition names as runtime
+   configuration passed in via the `params` map — never hard-code them.
+5. Target the `develop` branch for any change, and reference the tracking
+   issue in commits/PRs.
+
+### Do not
+
+1. Do not describe this repository as a software HSM simulator, SoftHSM
+   setup, or dev-only mock — it integrates with real HSM hardware/services.
+2. Do not commit vendor SDK JARs (`cloudhsm-jce`, `nfkm`, `luna`) into this
+   repository — they are proprietary and must be installed locally by each
+   developer/CI environment.
+3. Do not hard-code or commit real HSM credentials, hostnames, slot
+   numbers, or partition names anywhere in source or history.
+4. Do not invent a root-level Maven build command — there is no aggregator
+   `pom.xml`; each module must be built from its own directory.
+5. Do not claim CI validates changes here — there is no
+   `.github/workflows` directory in this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,16 +110,16 @@ hsm-ref-impl/
   LICENSE
   README.md
   hsm-keystore-impl/
-    aws-cloudhsm-impl/
+    aws-cloudhsm-impl/       # AGENTS.md
       pom.xml
       src/main/java/io/mosip/keymanager/hsm/impl/
         AWSCloudHSMKeyStoreImpl.java
         ApplicationCallBackHandler.java
-    ncipher-hsm-impl/
+    ncipher-hsm-impl/        # AGENTS.md
       pom.xml
       src/main/java/io/mosip/keymanager/hsm/impl/
         NCipherHSMKeyStoreImpl.java
-    safenet-luna-impl/
+    safenet-luna-impl/       # AGENTS.md
       pom.xml
       src/main/java/io/mosip/keymanager/hsm/impl/
         SafenetLunaKeyStoreImpl.java
@@ -140,11 +140,13 @@ hsm-ref-impl/
   reference cache (`enableKeyReferenceCache`, controlled by the
   `KeymanagerConstant.FLAG_KEY_REF_CACHE` param) — the other two modules do
   not cache key entries.
-- This is a small, flat repository. A single root `AGENTS.md` is
-  sufficient; no per-module `AGENTS.md` files were added because the three
-  modules share one build tool, one Java target, and one interface
-  contract, and differ only in which vendor JAR and credential fields they
-  use (documented above).
+- Each of the three modules also has its own `AGENTS.md`
+  (`hsm-keystore-impl/<vendor>-impl/AGENTS.md`) documenting that
+  module's implementation-class internals (constructor flow, vendor-SDK-
+  specific behavior, resilience/caching differences between modules) in
+  more depth than is useful to repeat here. Start with this root file
+  for what's shared (build tool, Java target, interface contract,
+  credential handling); go to the module guide for the rest.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,17 +149,18 @@ hsm-ref-impl/
 ## Development Workflow
 
 1. Fork the repository and clone your fork.
-2. Branch from `develop` (the repository's actual integration branch —
-   `git ls-remote` shows both `develop` and `develop-java21`; `develop` is
-   the current MOSIP target branch for new work unless a maintainer tells
-   you otherwise).
-3. Make changes inside the relevant module directory only
-   (`hsm-keystore-impl/<vendor>-impl/`).
+2. Branch from `develop`, unless repository settings or a maintainer
+   specify another target branch.
+3. Keep code changes scoped to the relevant module directory
+   (`hsm-keystore-impl/<vendor>-impl/`) where practical — modules are
+   built and released independently. Root documentation, shared
+   contract updates, and repository-level workflow changes are
+   naturally repo-wide and are not bound by this.
 4. Build that module with Maven as shown above and fix any compile errors.
    Because there are no unit tests, manual/integration verification against
-   real (or vendor-provided test) HSM hardware is the only way to confirm
-   runtime behavior — do not assume a clean `mvn compile` means the HSM
-   integration works.
+   real (or vendor-provided test) HSM hardware is required to confirm HSM
+   provider, authentication, and key-operation integration — do not assume
+   a clean `mvn compile` means the HSM integration works.
 5. Keep the three implementations' method behavior consistent with each
    other and with the shared `io.mosip.kernel.core.keymanager.spi.KeyStore`
    contract unless a vendor SDK genuinely forces a difference; note any such
@@ -202,8 +203,9 @@ hsm-ref-impl/
 1. Verify any new build, test, or config claim against the actual
    `pom.xml` and `.java` files in the relevant module before writing it
    down.
-2. Work inside a single module directory (`hsm-keystore-impl/<vendor>-impl`)
-   per change, and build that module with Maven to confirm it compiles.
+2. Prefer working inside a single module directory
+   (`hsm-keystore-impl/<vendor>-impl`) per change, and build that module
+   with Maven to confirm it compiles.
 3. Keep the three vendor implementations' public method behavior aligned
    with the shared `io.mosip.kernel.core.keymanager.spi.KeyStore` interface
    contract.

--- a/hsm-keystore-impl/aws-cloudhsm-impl/AGENTS.md
+++ b/hsm-keystore-impl/aws-cloudhsm-impl/AGENTS.md
@@ -1,0 +1,124 @@
+# AGENTS.md — hsm-keystore-impl/aws-cloudhsm-impl/
+
+Parent guide: [`../../AGENTS.md`](../../AGENTS.md)
+
+## Purpose
+
+AWS CloudHSM implementation of `io.mosip.kernel.core.keymanager.spi.KeyStore`,
+backed by AWS's `cloudhsm-jce` provider. Talks to a real (or vendor test)
+CloudHSM cluster — there is no local/simulated mode.
+
+## Layout
+
+```text
+aws-cloudhsm-impl/
+├── pom.xml
+└── src/main/java/io/mosip/keymanager/hsm/impl/
+    ├── AWSCloudHSMKeyStoreImpl.java     # the KeyStore implementation (~560 lines)
+    └── ApplicationCallBackHandler.java   # JAAS CallbackHandler used to supply the HSM login PIN
+```
+
+## `AWSCloudHSMKeyStoreImpl` structure
+
+Constructor (`AWSCloudHSMKeyStoreImpl(Map<String, String> params)`) does,
+in order: read config from `params` → `setupProvider()` (instantiate
+`CloudHsmProvider`) → `addProvider()` (register it with
+`java.security.Security`, removing any stale registration first) →
+`loginHSM(cuUserName, cuPassword)` (via `ApplicationCallBackHandler`) →
+`initKeystore()` (load/create the local `KeyStore` reference file at
+`keyStoreFilePath`) → `initKeyReferenceCache()` if
+`enableKeyReferenceCache` is set. Any failure at any of these steps
+throws immediately — there is no partial/degraded-mode construction.
+
+Notable behavior not obvious from the interface alone:
+
+- **Local keystore reference file**: `keyStoreFilePath` is a local file
+  that AWS's JCE provider uses to track key handles/labels — CloudHSM
+  itself holds the actual key material. `persistKeyInHSM()` rewrites
+  this file after every key create/store. Losing this file does **not**
+  lose the keys in the HSM, but does break this implementation's ability
+  to find them via the standard `KeyStore` API without extra recovery
+  steps.
+- **Retry + provider reload on `getAsymmetricKey`**: if the underlying
+  `KeyStoreException` is thrown while fetching a private key entry, the
+  code calls `reloadProvider()` (re-instantiates and re-registers the
+  CloudHsmProvider, reloads the keystore) and retries, up to
+  `NO_OF_RETRIES` (3) times. `reloadProvider()` itself is
+  rate-limited via `lastProviderLoadedTime` +
+  `PROVIDER_ALLOWED_RELOAD_INTERVEL_IN_SECONDS` (60s) — it silently
+  no-ops (just logs a warning) if called again within that window. Keep
+  this rate-limit in mind if you change retry behavior: removing it
+  could hammer the HSM connection on a persistent failure.
+- **Optional in-memory key reference cache**: this is the only one of
+  the three modules with this feature (`enableKeyReferenceCache`,
+  driven by the `KeymanagerConstant.FLAG_KEY_REF_CACHE` param).
+  `privateKeyReferenceCache`/`secretKeyReferenceCache` are plain
+  `ConcurrentHashMap`s with no eviction/TTL — every key ever fetched
+  stays cached for the life of the JVM instance when this flag is on.
+- **RSA key generation attributes**: `generateKeyPair()` builds explicit
+  `KeyAttributesMap`s for public (`VERIFY`, `ENCRYPT`, `MODULUS_BITS`,
+  fixed public exponent `65537`) and private (`SIGN`, `DECRYPT`) key
+  halves via AWS's `KeyAttributesMapBuilder`/`KeyPairAttributesMapBuilder`
+  — this is CloudHSM-SDK-specific API, not standard JCE
+  `AlgorithmParameterSpec`.
+
+## `ApplicationCallBackHandler`
+
+A minimal `javax.security.auth.callback.CallbackHandler`: constructed
+with the `cuUser:cuPassword` string, and on `handle()` sets that value
+as the password for any `PasswordCallback` it receives. This is how the
+constructor's `cloudHSMProvider.login(null, loginHandler)` call actually
+supplies credentials to AWS's JCE provider — there's no other login path
+in this module.
+
+## Build & Test Commands
+
+```bash
+cd hsm-keystore-impl/aws-cloudhsm-impl
+mvn clean install
+```
+
+Requires `com.amazonaws.cloudhsm:cloudhsm-jce:5.14.0` and
+`io.mosip.kernel:kernel-keymanager-service:1.2.1-SNAPSHOT` (classifier
+`lib`) to already be resolvable — see the parent guide's Configuration
+section for installing the vendor JAR locally. No unit tests exist;
+verification is manual/integration against a real or vendor-test
+CloudHSM cluster.
+
+## Configuration
+
+Constructor `params` keys this module reads (see parent guide's
+Configuration section for the shared `KeymanagerConstant` keys used by
+all three modules):
+
+| Key | Purpose |
+|---|---|
+| `keyStoreType` | JCE keystore type string passed to `KeyStore.getInstance` |
+| `keyStoreFile` | Path to the local key-reference file (see above) |
+| `localKeyStorePwd` | Password protecting that local reference file — **not** the HSM crypto-user password |
+| `cuUserName` | CloudHSM crypto user (CU) username |
+| `cuPassword` | CloudHSM crypto user password |
+| `KeymanagerConstant.FLAG_KEY_REF_CACHE` | Enables the in-memory key reference cache described above |
+
+## Agent rules
+
+### Do
+
+1. Preserve the retry + rate-limited-reload pattern in
+   `getAsymmetricKey`/`reloadProvider` if you touch error handling there
+   — it exists to tolerate transient CloudHSM connection issues without
+   hammering the provider on persistent failure.
+2. Keep `ApplicationCallBackHandler` as the only login path — don't
+   introduce a second way to authenticate to the provider.
+3. Treat `keyStoreFilePath` as a local reference cache, not the source
+   of truth for key material — the HSM is.
+
+### Do not
+
+1. Do not remove or shorten `PROVIDER_ALLOWED_RELOAD_INTERVEL_IN_SECONDS`
+   without understanding it's a deliberate rate limit on provider
+   reloads, not an arbitrary constant.
+2. Do not assume `enableKeyReferenceCache` behavior applies to the other
+   two modules — it's AWS-CloudHSM-specific.
+3. Do not hard-code `cuUserName`/`cuPassword`/`localKeyStorePwd` — they
+   must keep flowing in via the constructor's `params` map.

--- a/hsm-keystore-impl/ncipher-hsm-impl/AGENTS.md
+++ b/hsm-keystore-impl/ncipher-hsm-impl/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md — hsm-keystore-impl/ncipher-hsm-impl/
+
+Parent guide: [`../../AGENTS.md`](../../AGENTS.md)
+
+## Purpose
+
+nCipher / Thales nShield HSM implementation of
+`io.mosip.kernel.core.keymanager.spi.KeyStore`, backed by nCipher's
+`nfkm`/`nCipherKM` JCE provider. Talks to a real (or vendor test)
+nShield Security World — there is no local/simulated mode. This is the
+only one of the three modules with an extra MOSIP dependency,
+`io.mosip.kernel:kernel-core`, beyond `kernel-keymanager-service`.
+
+## Layout
+
+```text
+ncipher-hsm-impl/
+├── pom.xml
+└── src/main/java/io/mosip/keymanager/hsm/impl/
+    └── NCipherHSMKeyStoreImpl.java   # the KeyStore implementation (~410 lines) — no separate callback handler class, unlike aws-cloudhsm-impl
+```
+
+## `NCipherHSMKeyStoreImpl` structure
+
+Constructor (`NCipherHSMKeyStoreImpl(Map<String, String> params)`) reads
+config from `params`, then `initKeystore()`: instantiate `nCipherKM`
+provider → `addProvider()` (register with `java.security.Security`,
+removing any stale registration first) → read the card protection
+password → `nCipherKM.getSW()` to get the current
+`SecurityWorld` → `loadFIPSAuth(secWorld)` → `getKeystoreInstance()`
+(load/create the local key-reference file at `keyStoreFilePath`,
+protected by the card password).
+
+Notable behavior not obvious from the interface alone:
+
+- **`loadFIPSAuth`** iterates every `Module` in the Security World and,
+  for each module's slot 0 (skipping modules with no slot 0), calls
+  `secWorld.loadFipsAuth(slot)`. This is nCipher-specific FIPS
+  authentication setup required before the provider can use the module
+  — it has no equivalent in the AWS or SafeNet Luna modules.
+- **`System.setProperty(NFAST_PROTECT, PROTECT_TYPE)`** — sets the JVM
+  system property `protect=cardset` before creating the `KeyStore`
+  instance. This tells the nCipher provider that keys are protected by
+  an Operator Card Set (as opposed to, e.g., a softcard). If a
+  deployment uses a different protection method, this line needs to
+  change — don't assume `cardset` is universal across all nCipher
+  deployments.
+- **No retry/reload logic**: unlike `aws-cloudhsm-impl`, this module
+  does not retry or reload the provider on `KeyStoreException` in
+  `getAsymmetricKey` — a single failure propagates immediately as a
+  `KeystoreProcessingException`. Don't assume the two modules have
+  matching resilience behavior.
+- **No key reference cache**: unlike `aws-cloudhsm-impl`, there is no
+  in-memory caching of fetched keys — every `getAsymmetricKey`/
+  `getSymmetricKey` call re-reads the local key-reference file.
+- **Key generation uses standard JCE, not vendor-specific attribute
+  maps**: `generateKeyPair`/`generateSymmetricKey` call plain
+  `KeyPairGenerator.getInstance(alg, providerName)` /
+  `KeyGenerator.getInstance(alg, providerName)` with a `SecureRandom`,
+  unlike `aws-cloudhsm-impl`'s CloudHSM-specific
+  `KeyAttributesMapBuilder` API.
+
+## Build & Test Commands
+
+```bash
+cd hsm-keystore-impl/ncipher-hsm-impl
+mvn clean install
+```
+
+Requires `com.ncipher.km:nfkm:1.0.0`,
+`io.mosip.kernel:kernel-keymanager-service:1.2.1-SNAPSHOT` (classifier
+`lib`), and `io.mosip.kernel:kernel-core:1.2.1-SNAPSHOT` to already be
+resolvable — see the parent guide's Configuration section for installing
+the vendor JAR locally. No unit tests exist; verification is
+manual/integration against a real or vendor-test nShield HSM.
+
+## Configuration
+
+Constructor `params` keys this module reads (see parent guide's
+Configuration section for the shared `KeymanagerConstant` keys used by
+all three modules):
+
+| Key | Purpose |
+|---|---|
+| `keyStoreType` | JCE keystore type string passed to `KeyStore.getInstance` |
+| `keyStoreFile` | Path to the local key-reference file |
+| `cardProtection` | The Operator Card Set password — **not** a generic "keystore password"; the provider/property setup (`protect=cardset`) assumes card-set protection specifically |
+
+## Agent rules
+
+### Do
+
+1. Keep `loadFIPSAuth` and the `protect=cardset` system property set
+   before any `KeyStore.getInstance` call — both are required setup
+   steps specific to this vendor's provider.
+2. Verify any change against this module's actual (simpler, no
+   retry/cache) error-handling behavior rather than assuming it matches
+   `aws-cloudhsm-impl`.
+
+### Do not
+
+1. Do not assume `cardset` protection is the only valid nCipher
+   protection mode — it's what this module currently hard-codes via
+   `System.setProperty`, not a documented constraint from the vendor SDK.
+2. Do not port `aws-cloudhsm-impl`'s retry/reload or key-reference-cache
+   logic here without discussing it — this module's simpler
+   fail-immediately behavior may be intentional for this vendor's
+   connection characteristics.
+3. Do not hard-code `cardProtection` — it must keep flowing in via the
+   constructor's `params` map.

--- a/hsm-keystore-impl/safenet-luna-impl/AGENTS.md
+++ b/hsm-keystore-impl/safenet-luna-impl/AGENTS.md
@@ -1,0 +1,107 @@
+# AGENTS.md — hsm-keystore-impl/safenet-luna-impl/
+
+Parent guide: [`../../AGENTS.md`](../../AGENTS.md)
+
+## Purpose
+
+SafeNet Luna HSM implementation of
+`io.mosip.kernel.core.keymanager.spi.KeyStore`, backed by SafeNet's
+`com.safenetinc.luna.provider.LunaProvider`. Talks to a real (or vendor
+test) Luna partition — there is no local/simulated mode. Like
+`ncipher-hsm-impl`, this module depends on both
+`io.mosip.kernel:kernel-core` and `kernel-keymanager-service`.
+
+## Layout
+
+```text
+safenet-luna-impl/
+├── pom.xml
+└── src/main/java/io/mosip/keymanager/hsm/impl/
+    └── SafenetLunaKeyStoreImpl.java   # the KeyStore implementation (~370 lines)
+```
+
+## `SafenetLunaKeyStoreImpl` structure
+
+Constructor (`SafenetLunaKeyStoreImpl(Map<String, String> params)`)
+reads config from `params`, then `initKeystore()`: instantiate
+`LunaProvider` → `addProvider()` (register with `java.security.Security`,
+removing any stale registration first) → read the partition password →
+`getKeystoreInstance()`.
+
+Notable behavior specific to this module:
+
+- **No local key-reference file.** `getKeystoreInstance()` loads the
+  `KeyStore` from a `ByteArrayInputStream` built from the literal string
+  `"slot:" + slotNumber` — it points the Luna provider at a specific
+  HSM slot directly, not at a local file. Correspondingly,
+  `persistKeyInHSM()` calls `keyStore.store(null, partitionPwdCharArr)`
+  — a **null output stream** — because there's nothing local to write
+  to; the Luna provider persists key operations straight to the HSM
+  slot. This is different from both `aws-cloudhsm-impl` and
+  `ncipher-hsm-impl`, which maintain a local key-reference file at a
+  `keyStoreFile` path — do not add a `keyStoreFile`/local-file pattern
+  here without understanding this module doesn't need one.
+- **No retry/reload logic and no key reference cache** — same as
+  `ncipher-hsm-impl`, a single `KeyStoreException` during
+  `getAsymmetricKey` propagates immediately; nothing is cached in
+  memory across calls. Do not assume this module matches
+  `aws-cloudhsm-impl`'s resilience/caching behavior.
+- **Inconsistent provider argument in key generation**: asymmetric key
+  generation calls `KeyPairGenerator.getInstance(asymmetricKeyAlgorithm)`
+  (no explicit provider name — relies on whichever provider is first in
+  the JVM's provider list for that algorithm), while symmetric key
+  generation calls `KeyGenerator.getInstance(symmetricKeyAlgorithm,
+  lunaProvider.getName())` (explicit provider). This asymmetry exists in
+  the current code — verify which provider actually services the
+  asymmetric call in your environment before assuming it's always
+  `LunaProvider`, and flag it in review if you touch this method.
+
+## Build & Test Commands
+
+```bash
+cd hsm-keystore-impl/safenet-luna-impl
+mvn clean install
+```
+
+Requires `com.safenetinc:luna:1.10.0`,
+`io.mosip.kernel:kernel-keymanager-service:1.2.1-SNAPSHOT` (classifier
+`lib`), and `io.mosip.kernel:kernel-core:1.2.1-SNAPSHOT` to already be
+resolvable — see the parent guide's Configuration section for installing
+the vendor JAR locally. No unit tests exist; verification is
+manual/integration against a real or vendor-test Luna HSM.
+
+## Configuration
+
+Constructor `params` keys this module reads (see parent guide's
+Configuration section for the shared `KeymanagerConstant` keys used by
+all three modules):
+
+| Key | Purpose |
+|---|---|
+| `keyStoreType` | JCE keystore type string passed to `KeyStore.getInstance` |
+| `slotNo` | The Luna HSM slot number to load the keystore from (no local file involved) |
+| `partitionPwd` | The Luna partition password |
+
+## Agent rules
+
+### Do
+
+1. Keep the slot-based `KeyStore` loading (`"slot:" + slotNumber`) and
+   the `store(null, ...)` persistence call as-is — there is no local
+   file for this module to write to, unlike the other two.
+2. Verify which security provider actually resolves
+   `asymmetricKeyAlgorithm` before relying on the no-explicit-provider
+   `KeyPairGenerator.getInstance` call, since it doesn't pin
+   `LunaProvider` explicitly the way the symmetric path does.
+
+### Do not
+
+1. Do not add a `keyStoreFile`/local-reference-file parameter to this
+   module by copying the pattern from `aws-cloudhsm-impl` or
+   `ncipher-hsm-impl` — this module's `KeyStore` is loaded directly from
+   an HSM slot and has no local file to manage.
+2. Do not assume this module retries or caches like
+   `aws-cloudhsm-impl` — it fails immediately on the first
+   `KeyStoreException` and caches nothing.
+3. Do not hard-code `partitionPwd`/`slotNo` — they must keep flowing in
+   via the constructor's `params` map.


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds a root AGENTS.md covering repository overview, technology stack, module-by-module build commands, HSM vendor SDK configuration notes, project structure, development workflow, PR guidelines, and repository-specific security considerations for AI coding assistants and contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance for HSM modules, prerequisites, runtime configuration, development workflows, and pull-request expectations.
  * Documented security requirements for proprietary SDKs, credentials, vendor artifacts, and HSM runtime access.
  * Added implementation-specific guidance for AWS CloudHSM, nCipher, and SafeNet Luna integrations.
  * Clarified initialization behavior, authentication, key storage, provider handling, retries, caching, build requirements, and configuration options.
  * Added project structure details, development rules, module build guidance, and repository constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->